### PR TITLE
Helm: Create required RBAC in OpenShift

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -32,7 +32,9 @@ roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view
   apiGroup: rbac.authorization.k8s.io
-{{- else }}
+{{- end }}
+{{/* Always create rest of the RBAC permissions when operator is enabled */}}
+{{- if or (not .Values.ocpCompatibility.enabled) .Values.yugaware.kubernetesOperatorEnabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Summary:
Currently, only the monitoring related ClusterRoleBinding is created when running in OpenShift and rbac.create=true is set. In case of the operator, we need permissions to manage the custom resources as well as have abilitiy to create universes using the in-cluster credentials.

With this change we create the required RBAC permissions for OpenShift as well i.e. ocpCompatibility.enabled=true.

Fixes https://github.com/yugabyte/yugabyte-k8s-operator/issues/6

Test plan:
Tried doing Helm template with following commands:

No change in the default behavior.
```
helm template .
```

Creates all the RBAC resources along with the monitoring one.
```
helm template . --set ocpCompatibility.enabled=true
```

Based on my limited testing on an actual OpenShift cluster, we might have more issues to fix to get the operator working on OpenShift. 