### PR TITLE
Add finalizer removal hook during helm delete for common case for release CR

### DIFF
--- a/chart/templates/finalizer_removal_hook.yaml
+++ b/chart/templates/finalizer_removal_hook.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: remove-finalizers
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
+      restartPolicy: Never
+      containers:
+      - name: remove-finalizers
+        image: bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Removing finalizers from resources..."
+            kubectl get Release -o json --namespace {{ .Release.Namespace }} | jq -r '.items[] | select(.metadata.finalizers != null) | .metadata.name' | \
+            xargs -I {} kubectl patch Release {} --type merge -p '{"metadata":{"finalizers":[]}}' --namespace {{ .Release.Namespace }}
+


### PR DESCRIPTION

# Describe your changes
Due to new finalizer behavior for releases, we may leave releases hanging around in the namespace after
chart has been deleted. 
This change fixes that behavior for the common case where the operator is working in namespace mode 
and operator namespace is same as the cr namespace. 


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
```
anijhawan@CYWWYVVT7L templates % helm ls -n operator-test
NAME            	NAMESPACE    	REVISION	UPDATED                             	STATUS  	CHART                      	APP VERSION
chart-1734653701	operator-test	1       	2024-12-19 16:15:02.657514 -0800 PST	deployed	yugabyte-k8s-operator-0.1.5	2.25
anijhawan@CYWWYVVT7L templates % helm delete -n operator-test chart-1734653701
release "chart-1734653701" uninstalled
anijhawan@CYWWYVVT7L templates % kubectl get release -n operator-test
No resources found in operator-test namespace.
```
